### PR TITLE
#12 공지사항 수정 API, #11 Add 공지사항 조회 API, #8 공지사항 조회 API, # 24 공지사항 전체 조회…

### DIFF
--- a/src/main/java/com/fairytaler/fairytalecat/community/command/application/controller/NoticeController.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/command/application/controller/NoticeController.java
@@ -1,10 +1,9 @@
-package com.fairytaler.fairytalecat.community.query.application.controller;
+package com.fairytaler.fairytalecat.community.command.application.controller;
 
 import com.fairytaler.fairytalecat.common.response.ResponseDTO;
 import com.fairytaler.fairytalecat.community.command.application.dto.NoticeRequestDTO;
-import com.fairytaler.fairytalecat.community.query.application.service.NoticeQueryService;
+import com.fairytaler.fairytalecat.community.command.application.service.NoticeService;
 import com.fairytaler.fairytalecat.jwt.TokenProvider;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,30 +11,29 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class NoticeController {
     static private TokenProvider tokenProvider;
-    static private NoticeQueryService noticeService;
-    public NoticeController(NoticeQueryService noticeService, TokenProvider tokenProvider){
+    static private NoticeService noticeService;
+    public NoticeController(NoticeService noticeService, TokenProvider tokenProvider){
         this.tokenProvider = tokenProvider;
         this.noticeService = noticeService;
     }
-
-    /* 공지사항 조회 */
-    @GetMapping("/notices/{noticeCode}")
-    public ResponseEntity<ResponseDTO> selectNotice(@PathVariable Long noticeCode){
-        /* role 확인 후, 관리자면 전체 조회, 일반 유저면 public 데이터만 조회*/
-
-        /* 공지사항이 있으면 조회 후 반환 */
-        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", noticeService.getNotice(noticeCode)));
+    
+    /* 공지사항 입력 */
+    @PostMapping("/notices")
+    public ResponseEntity<ResponseDTO> selectNoticeListWithPaging(@RequestBody NoticeRequestDTO noticeRequestDTO){
+        System.out.println(noticeRequestDTO);
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", noticeService.registNotice(noticeRequestDTO)));
     }
-
-    /* 공지사항 전체 조회 */
-    @GetMapping("/notices")
-    public ResponseEntity<ResponseDTO> selectNoticeListWithPaging(@RequestHeader String accessToken, Pageable pageable){
-        /* role 확인 후, 관리자면 전체 조회, 일반 유저면 public 데이터만 조회*/
-        String memberCode = tokenProvider.getUserCode(accessToken);
-        System.out.println("memberCode = " + memberCode);
-
-        /* 공지사항이 있으면 조회 후 반환 */
-        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", noticeService.getNoticeListWidthPaging(pageable).getContent()));
+    @PutMapping("/notices")
+    public ResponseEntity<ResponseDTO> updateNotice(@RequestBody NoticeRequestDTO noticeRequestDTO){
+        System.out.println(noticeRequestDTO);
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", noticeService.updateNotice(noticeRequestDTO)));
     }
-
+    @PutMapping("/notices/{noticeCode}")
+    public ResponseEntity<ResponseDTO> updateNoticeToPublic(@PathVariable Long noticeCode,@RequestParam(name="isPublic", defaultValue="true") boolean isPublic){
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 비공개 설정 성공",  noticeService.updateNoticeToPublic(noticeCode, isPublic)));
+    }
+    @DeleteMapping("/notices/{noticeCode}")
+    public ResponseEntity<ResponseDTO> privateNotice(@PathVariable Long noticeCode){
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 비공개 설정 성공", noticeService.deleteNotice(noticeCode)));
+    }
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/command/application/dao/NoticeDAO.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/command/application/dao/NoticeDAO.java
@@ -1,2 +1,7 @@
-package com.fairytaler.fairytalecat.community.command.application.dao;public class NoticeDAO {
+package com.fairytaler.fairytalecat.community.command.application.dao;
+
+import com.fairytaler.fairytalecat.community.command.domain.model.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeDAO extends JpaRepository<Notice, Long> {
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/command/application/dto/NoticeRequestDTO.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/command/application/dto/NoticeRequestDTO.java
@@ -1,15 +1,31 @@
 package com.fairytaler.fairytalecat.community.command.application.dto;
 
 public class NoticeRequestDTO {
-
+    private Long noticeCode;
     private String title;
-
     private String content;
 
-
-    public NoticeRequestDTO(String title, String content) {
+    public NoticeRequestDTO(Long noticeCode, String title, String content) {
+        this.noticeCode = noticeCode;
         this.title = title;
         this.content = content;
+    }
+
+    @Override
+    public String toString() {
+        return "NoticeRequestDTO{" +
+                "noticeCode=" + noticeCode +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                '}';
+    }
+
+    public Long getNoticeCode() {
+        return noticeCode;
+    }
+
+    public void setNoticeCode(Long noticeCode) {
+        this.noticeCode = noticeCode;
     }
 
     public void setTitle(String title) {
@@ -29,11 +45,4 @@ public class NoticeRequestDTO {
         return content;
     }
 
-    @Override
-    public String toString() {
-        return "NoticeRequestDTO{" +
-                "title='" + title + '\'' +
-                ", content='" + content + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/command/application/service/NoticeService.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/command/application/service/NoticeService.java
@@ -1,2 +1,68 @@
-package com.fairytaler.fairytalecat.community.command.application.service;public class NoticeService {
+package com.fairytaler.fairytalecat.community.command.application.service;
+
+import com.fairytaler.fairytalecat.community.command.application.dao.NoticeDAO;
+import com.fairytaler.fairytalecat.community.command.application.dto.NoticeRequestDTO;
+import com.fairytaler.fairytalecat.community.command.domain.model.Notice;
+import com.fairytaler.fairytalecat.community.query.application.dao.NoticeQueryDAO;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+public class NoticeService {
+
+    NoticeDAO noticeDAO;
+
+    public NoticeService(NoticeDAO noticeDAO){
+        this.noticeDAO = noticeDAO;
+    }
+
+    @Transactional
+    public Long registNotice(NoticeRequestDTO noticeRequestDTO) {
+        /* 데이터 생성 */
+        Notice notice = new Notice();
+        notice.setTitle(noticeRequestDTO.getTitle());
+        notice.setContent(noticeRequestDTO.getContent());
+        notice.setCreateDate(new Date());
+        notice.setPublic(true);
+
+        noticeDAO.save(notice);
+
+        return notice.getNoticeCode();
+    }
+    public Notice updateNotice(NoticeRequestDTO noticeRequestDTO){
+        Optional<Notice> oNotice = noticeDAO.findById(noticeRequestDTO.getNoticeCode());
+
+        /* 데이터 삽입 */
+        Notice notice = oNotice.get();
+
+        notice.setTitle(noticeRequestDTO.getTitle());
+        notice.setContent(noticeRequestDTO.getContent());
+
+        noticeDAO.save(notice);
+
+        return notice;
+    }
+    public Notice updateNoticeToPublic(Long noticeCode, boolean isPublic){
+        Optional<Notice> oNotice = noticeDAO.findById(noticeCode);
+
+        /* 데이터 삽입 */
+        Notice notice = oNotice.get();
+
+        notice.setPublic(isPublic);
+
+        noticeDAO.save(notice);
+
+        return notice;
+    }
+    public Long deleteNotice(Long noticeCode){
+        Optional<Notice> oNotice = noticeDAO.findById(noticeCode);
+        if(oNotice.isPresent()) {
+            noticeDAO.delete(oNotice.get());
+        }
+
+        return noticeCode;
+    }
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/command/domain/model/Notice.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/command/domain/model/Notice.java
@@ -1,15 +1,22 @@
 package com.fairytaler.fairytalecat.community.command.domain.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.util.Date;
 
 @Entity
+@SequenceGenerator(
+        name = "SEQ_NOTICE_CODE"
+        , sequenceName = "SEQ_NOTICE_CODE"
+        , initialValue = 1
+        , allocationSize = 1
+)
 @Table(name = "TB_NOTICE")
 public class Notice {
     @Id
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE
+            , generator = "SEQ_NOTICE_CODE"
+    )
     @Column(name="NOTICE_CODE")
     private long noticeCode;           //내용
     @Column(name="TITLE")

--- a/src/main/java/com/fairytaler/fairytalecat/community/query/application/controller/NoticeQueryController.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/query/application/controller/NoticeQueryController.java
@@ -1,7 +1,6 @@
 package com.fairytaler.fairytalecat.community.query.application.controller;
 
 import com.fairytaler.fairytalecat.common.response.ResponseDTO;
-import com.fairytaler.fairytalecat.community.command.application.dto.NoticeRequestDTO;
 import com.fairytaler.fairytalecat.community.query.application.service.NoticeQueryService;
 import com.fairytaler.fairytalecat.jwt.TokenProvider;
 import org.springframework.data.domain.Pageable;
@@ -10,10 +9,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-public class NoticeController {
+public class NoticeQueryController {
     static private TokenProvider tokenProvider;
     static private NoticeQueryService noticeService;
-    public NoticeController(NoticeQueryService noticeService, TokenProvider tokenProvider){
+    public NoticeQueryController(NoticeQueryService noticeService, TokenProvider tokenProvider){
         this.tokenProvider = tokenProvider;
         this.noticeService = noticeService;
     }
@@ -29,13 +28,11 @@ public class NoticeController {
 
     /* 공지사항 전체 조회 */
     @GetMapping("/notices")
-    public ResponseEntity<ResponseDTO> selectNoticeListWithPaging(@RequestHeader String accessToken, Pageable pageable){
+    public ResponseEntity<ResponseDTO> selectNoticeListWithPaging(@RequestParam(name="isPublic", defaultValue="N") String isPublic){
         /* role 확인 후, 관리자면 전체 조회, 일반 유저면 public 데이터만 조회*/
-        String memberCode = tokenProvider.getUserCode(accessToken);
-        System.out.println("memberCode = " + memberCode);
 
         /* 공지사항이 있으면 조회 후 반환 */
-        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", noticeService.getNoticeListWidthPaging(pageable).getContent()));
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "공지사항 조회 성공", isPublic));
     }
 
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/query/application/dao/NoticeQueryDAO.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/query/application/dao/NoticeQueryDAO.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface NoticeDAO extends JpaRepository<Notice, Long> {
+public interface NoticeQueryDAO extends JpaRepository<Notice, Long> {
     Optional<Notice> findByNoticeCode(Long noticeCode);
     Page<Notice> findAll(Pageable pageable);
 }

--- a/src/main/java/com/fairytaler/fairytalecat/community/query/application/service/NoticeQueryService.java
+++ b/src/main/java/com/fairytaler/fairytalecat/community/query/application/service/NoticeQueryService.java
@@ -1,28 +1,33 @@
 package com.fairytaler.fairytalecat.community.query.application.service;
 
 import com.fairytaler.fairytalecat.community.command.domain.model.Notice;
-import com.fairytaler.fairytalecat.community.query.application.dto.NoticeResponseDTO;
-import com.fairytaler.fairytalecat.community.query.application.dao.NoticeDAO;
+import com.fairytaler.fairytalecat.community.query.application.dao.NoticeQueryDAO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
 import java.util.Optional;
 
 @Service
 public class NoticeQueryService {
-    private NoticeDAO noticeDao;
+    private NoticeQueryDAO noticeDao;
 
-    public NoticeQueryService(NoticeDAO noticeDao){
+    public NoticeQueryService(NoticeQueryDAO noticeDao){
         this.noticeDao = noticeDao;
     }
-
-    public NoticeResponseDTO selectNotice(int noticeCode){
-        return new NoticeResponseDTO(noticeCode,"공지사항", "내용","Y", new Date());
-    }
-
     public Optional<Notice> getNotice(Long noticeCode){
         /* 공지사항 조회 */
         Optional<Notice> notice = noticeDao.findByNoticeCode(noticeCode);
+        if(notice == null){
+//            throw new NoMemberException(); //예외 처리
+            System.out.println("해당 번호의 공지사항이 없습니다.");
+        }
+        return notice;
+    }
+
+    public Page<Notice> getNoticeListWidthPaging(Pageable pageable){
+        Page<Notice> notice = noticeDao.findAll(pageable);
+
         if(notice == null){
 //            throw new NoMemberException(); //예외 처리
             System.out.println("해당 번호의 공지사항이 없습니다.");

--- a/src/main/java/com/fairytaler/fairytalecat/jwt/TokenProvider.java
+++ b/src/main/java/com/fairytaler/fairytalecat/jwt/TokenProvider.java
@@ -53,7 +53,6 @@ public class TokenProvider {
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
-
         return new TokenDTO(BEARER_TYPE, member.getMemberName(), accessToken, accessTokenExpiresIn.getTime());
      }
 
@@ -91,7 +90,6 @@ public class TokenProvider {
                          .map(SimpleGrantedAuthority::new)
                          .collect(Collectors.toList());
         UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserId(accessToken));
-
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
     }

--- a/src/main/java/com/fairytaler/fairytalecat/tale/command/application/service/InsertTaleService.java
+++ b/src/main/java/com/fairytaler/fairytalecat/tale/command/application/service/InsertTaleService.java
@@ -41,7 +41,6 @@ public class InsertTaleService {
         tale.setMemberCode(memberCode);
         System.out.println("[insertTaleService : Tale entity] \n" + tale);
 
-
         /* 테일 */
 //        if (mongoDBTestRepository.findByName(name) != null) {
 //            log.info("[Service][update] name is already exist!!");


### PR DESCRIPTION
## 개요
공지사항 관련 API 구현
## 작업 사항
- 공지사항 조회
- 공지사항 입력
- 공지사항 삭제
- 공지사항 전체 조회
- 공지사항 수정
- 공지사항 비공개 설정

## 변경로직
### 변경전
- 없음
### 변경후
- 공지사항 조회
- 공지사항 입력
- 공지사항 삭제
- 공지사항 전체 조회
- 공지사항 수정
- 공지사항 비공개 설정
## 사용방법
- 공지사항 조회 ( http://localhost:8080/notices/3)
- 공지사항 입력 (http://localhost:8080/notices)
 {
   "title" : "공지사항 테스트",
   "content" : "공지사항 테스트"
   }
- 공지사항 삭제 ((http://localhost:8080/notices/4))
- 공지사항 전체 조회 (http://localhost:8080/notices?page=0&size=5)
- 공지사항 수정 (http://localhost:8080/notices)
   {
    "noticeCode" : "4",
    "title" : "공지사항 테스트",
    "content" : "공지사항 테스트222"
   }
- 공지사항 비공개 설정 (http://localhost:8080/notices/1?isPublic=false)
## 기타
